### PR TITLE
Add reservation api

### DIFF
--- a/docs/articles/how-to-build-a-reservation-chatbot.md
+++ b/docs/articles/how-to-build-a-reservation-chatbot.md
@@ -14,7 +14,7 @@ author: Sunny May
 [[toc]]
 
 ## Overview
-Following the [requirements on making a reservation](./requirements-on-reservation.md#make-a-reservation), this guide shows you how to build a reservation chatbot step by step with a [reservation service](./how-to-build-a-reservation-service.md).
+Following the [requirements on making a reservation](./requirements-on-reservation.md#make-a-reservation), this guide shows you how to build a reservation chatbot step by step with a [reservation service](./reservation-service.md).
 
 **What do you build?**
 - A [component](../guide/concepts.md#components) that provides reusable [conversational user interaction (CUI) components](../guide/components.md#conversational-user-interaction-cui-component). 
@@ -30,10 +30,10 @@ Read the following articles first and get familiar with the basic concepts and o
 2. [Key concept](../guide/concepts.md) helps you to understand the type system and the roles of different projects.
 3. [Slot filling](../guide/slotfilling.md) helps you to design how the bot interacts with users.
 
-Besides, be sure you've followed [how to build a reservation service](./how-to-build-a-reservation-service.md) to build the component and provider for reservation service.
+Besides, be sure you've followed [reservation API](./reservation-service.md) and [how to implement a reservation service](./how-to-build-a-reservation-service.md) to build the component and provider for reservation service.
 
 ## Component 
-In this section, you add [CUI components](../guide/components.md#conversational-user-interaction-cui-component) to the [reservation component](./how-to-build-a-reservation-service.md#component).
+In this section, you add [CUI components](../guide/components.md#conversational-user-interaction-cui-component) to the [reservation component](./reservation-service.md#create-a-component).
 
 ### Add Slots & Annotations
 To make a reservation, the information needed is the user ID, date, time and type of table. You need to create a [skill](../guide/concepts.md#skills) and add four slots to store the information. To get an ID of a user automatically without asking the user, you can use a system CUI frame called [user.UserIdentifier](../reference/annotations/systemcomponent.md#user-identifier). A slot called *userId* in this frame is a channel-dependent identifier of the user.
@@ -71,9 +71,9 @@ Besides,  you need to add the following annotations:
 :::
 
 :tipping_hand_woman: Now you can follow the steps below to add schema and annotations:
-1. [Import](../reference/platform/reusability.md#import-1) [*io.opencui.core*](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/633f953f28e4f04b5f8443b7/intent?page=0&imported=false&search=) to the [reservation component](./how-to-build-a-reservation-service.md#component).
+1. [Import](../reference/platform/reusability.md#import-1) [*io.opencui.core*](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/633f953f28e4f04b5f8443b7/intent?page=0&imported=false&search=) to the [reservation component](./reservation-service.md#create-a-component).
 2. In the reservation component, create a skill called **MakeReservation**.
-3. In the **MakeReservation** skill, add a **userId** slot of which type is *io.opencui.core.user.UserIdentifier​* and [use a frame](../reference/platform/reusability.md#compose-1) of which type is *ReservationInfo*.
+3. In the **MakeReservation** skill, add a **userId** slot of which type is *io.opencui.core.user.UserIdentifier* and [use a frame](../reference/platform/reusability.md#compose-1) of which type is *ReservationInfo*.
 4. To invoke functions imported from the service, add a service slot in the **Services** section in the skill.
 5. Add the above annotations needed by each slot to implement the interaction logic.
 
@@ -92,14 +92,12 @@ In the previous sections, you've done development at the structure level. In thi
 
 **Expressions**
 
-When a user wants to make a reservation, he might say "*make a reservation*" or he might mention a specific date, like "*book a table tomorrow*". To cover the above situations, the expressions you need to add to the skill are: 
+When a user wants to make a reservation, he might say "*make a reservation*" or he might mention a specific date, like "*book a table tomorrow*". To cover the above situations, the expressions you need to add to the **MakeReservation** skill are: 
 
-| Skill                   | Expressions                 |
-|:------------------------|:----------------------------|
-| MakeReservation         | make a reservation          |
-|                         | book a table $date$         |
-|                         | book a table $time$         |
-|                         | book a table $tableType$    |
+- make a reservation
+- book a table $date$
+- book a table $time$
+- book a table $tableType$
 
 ::: warning Warning
 Do **NOT** copy and paste the text in `$$` but type the text instead.
@@ -142,36 +140,29 @@ Besides, the templates you need to define in reseponse are:
 In this section, you reuse [CUI components](../guide/components.md#conversational-user-interaction-cui-component) and customize a builder-defined entity.
 
 ### Import Component
-:tipping_hand_woman: To begin with, you need to create an [OpenCUI-hosted](../guide/glossary.md#deploy-mode) chatbot and [import](../reference/platform/reusability.md#import-1) the [reservation component](#component) into the chatbot.
+To begin with, you need to create an [OpenCUI-hosted](../guide/glossary.md#deploy-mode) chatbot and [import](../reference/platform/reusability.md#import-1) the [reservation component](#component) into the chatbot.
 
 ### Set Integration
-:tipping_hand_woman: Next, when your [reservation provider](./how-to-build-a-reservation-service.md#provider) is ready, you can [integrate the provider with your chatbot](../reference/providers/postgrest.md#wire-to-chatbot) to get access to the reservation service. 
+Next, when your [reservation provider](./how-to-build-a-reservation-service.md) is ready, you can [integrate the provider with your chatbot](../reference/providers/postgrest.md#wire-to-chatbot) to get access to the reservation service. 
 
 ::: tip Tip
 If your provider is not ready, you can just move on to the next step but be sure to set the integration before the [testing](../reference/platform/testing.md).
 :::
 
 ### Add Instances
-For now, there is no [entity instance](../guide/glossary.md#entity) added to the **TableType** entity. 
-
-:tipping_hand_woman: To complete the entity, you need to add the following instances to the imported entity: TableType.
-
-| Imported Entity    | Instance |
-|:-------------------|:---------|
-| TableType          | small​    |
-|                    | medium   |
-|                    | large    |
+For now, there is no [entity instance](../guide/glossary.md#entity) added to the **TableType** entity. You need to add the following instances to the **TableType** entity.
+- small
+- medium
+- large
 
 ### Add Expressions
-At a language level, there is no expression for instances in the **TableType** entity. 
+At a language level, there is no expression for instances in the **TableType** entity. You need to **switch to the** [**EN agent**](../reference/platform/multilingual.md#add-multi-language) and add expressions to the **TableType** entity for each instance.
 
-:tipping_hand_woman: To complete the entity, you need to **switch to the** [**EN agent**](../reference/platform/multilingual.md#add-multi-language) and add expressions for each instance.
-
-| Entity    | Instance | Expressions                |
-|:----------|:---------|:---------------------------|
-| TableType | small​    | small <br>small table      |
-|           | medium   | medium <br>medium table    |
-|           | large    | large <br>large table      |
+| Instance | Expressions                                      |
+|:---------|:-------------------------------------------------|
+| small    | <ul><li> small </li><li>small table </li></ul>   |
+| medium   | <ul><li> medium </li><li>medium table </li></ul> |
+| large    | <ul><li> large </li><li>large table </li></ul>   |
 
 ### What's Next
 Once you've built your chatbot, you can [test](../reference/platform/testing.md) it and see if it works as you expect. If it works well on the platform, you can try to deploy the chatbot to a [channel](../reference/channels/overview.md#opencui-extension-channel) and check the real conversation on a specific channel. You may use the [rich message](../reference/channels/universalmessage.md#rich-message) to provide a better experience for your users.

--- a/docs/articles/how-to-build-a-reservation-service.md
+++ b/docs/articles/how-to-build-a-reservation-service.md
@@ -64,7 +64,7 @@ To get available dates, time frames and types of tables, first you need tables t
 | tableType   | TableType             |
 | status      | kotlin.Int            |
 
-## Implement functions 
+## Implement Functions 
 Once you've created tables, you can implement the [function interfaces](./reservation-service.md#add-function-interfaces) imported from the reservation component. By doing so, your business can get access to your database and perform [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operation within it.
 
 :tipping_hand_woman: Now [select a service interface](../reference/providers/postgrest.md#provide-function-implementation) to implement. Next, copy the following codes to implement corresponding functions. Before you start to integrate the provider with a chatbot, be sure to use the [function console](../reference/providers/postgrest.md#function-console) to test functions first.

--- a/docs/articles/how-to-build-a-reservation-service.md
+++ b/docs/articles/how-to-build-a-reservation-service.md
@@ -5,103 +5,28 @@ date: 2022-12-26
 image:
     - blog/banner/tutorial_reservation_ii.png
 description:
-    - We show you the way to build a reservation service step by step
+    - We show you the way to implement a reservation service step by step
 author: Sunny May
 ---
 
-# How to Build a Reservation Service
+# How to Implement a Reservation Service
 
 [[toc]]
 
 ## Overview
-Following the [requirements on making a reservation](./requirements-on-reservation.md#make-a-reservation), this guide shows you how to build a reservation service step by step with an OpenCUI-hosted service. With this service, it will be easy for a reservation chatbot to help users to make a reservation.
-
-**What do you build?**
-- A [component](../guide/concepts.md#components) that provides a service interface and type system. 
-- A [provider](../guide/concepts.md#providers) that implements the service and provides the schema of a database. 
-
-::: tip Tip
-The sample of a component is [reservation](https://build.opencui.io/org/622c8ff683536204fe062b55/agent/63734ef820b0d2661d800404/service_schema) and of a provider is [reservationProvider](https://build.opencui.io/org/622c8ff683536204fe062b55/agent/6373805420b0d2661d806193/service_schema). If you have problems following procedures, you can always look for examples in this component and provider.
-:::
+This guide shows you how to implement a [reservation service](./reservation-service.md) using a [postgrest provider](../reference//providers/postgrest.md#overview). The sample of the provider is [reservationProvider](https://build.opencui.io/org/622c8ff683536204fe062b55/agent/6373805420b0d2661d806193/service_schema). If you have problems following procedures, you can always refer to that provider.
 
 ## Before You Start
 Read the following articles first and get familiar with the basic concepts and operation of the platform.
 1. [Quick start with pingpong](../guide/pingpong.md) teaches you how to build a simple chatbot which includes the basic operation of the platform.
-2. [Key concept](../guide/concepts.md) helps you to understand the type system and the roles of different projects.
+2. [Key concept](../guide/concepts.md) helps you to understand type systems and components.
 
-## Component 
-In this section, you create a [component](../guide//concepts.md#components) where you define [type systems](../guide/concepts.md#type-systems) and [services](../guide/concepts.md#services).
-
-### Create Types
-The data needed from users in making a reservation is a date, a time and a type of table. Date and time specify which day and what time the user will arrive at your restaurant. The type of table tells what kind of table the user books. The above information can be stored using [entities](../guide/concepts.md#entities). You can use pre-defined data to store the value of date and time. As for the type of table, you need to create a **TableType** entity to represent it. These three entities can be added to a **ReservationInfo** [frame](../guide/concepts.md#frames) so you can reuse them in different skills.
-
-Sometimes, you need to provide available options with more information covered.
-- For the time, the bot can provide time frames which include the start time and the end time.
-- For the type of table, the bot can provide the type of table, the minimum and the maximum number of guests which the table requires.
-
-In this situation, a **TableInfo** frame can cover all the additional information required by time and type of table. To sum up, the types you need to create are: 
-
-1. Entity: **TableType**
-
-2. Frame: **ReservationInfo**
-
-| Slot        | Type                  |
-|:------------|:----------------------|
-| date        | java.timeLocalDate    |
-| time        | java.time.LocalTime   |
-| tableType   | TableType             |
-
-3. Frame: **TableInfo**
-
-| Slot        | Type                  |
-|:------------|:----------------------|
-| date        | java.timeLocalDate    |
-| startTime   | java.time.LocalTime   |
-| endTime     | java.time.LocalTime   |
-| tableType   | TableType             |
-| minGuest    | kotlin.Int            |
-| maxGuest    | kotlin.Int            | 
-
-:tipping_hand_woman: Now you can follow these steps to create types: 
-1. Create a component with service enabled and [add the EN language](../reference/platform/multilingual.md#add-multi-language).
-2. Add the above three types in the component.
-
-::: tip Do NOT add instances to the TableType entity. Why?
-To make this component more flexible and let more people reuse it, you can leave the instance empty and let people who use this component add their own instances in their chatbots.
-:::
-
-### Add Function Interfaces
-To make a reservation, the business logic should include:
-1. Getting available values for date, time and the types of table. If the user has selected a certain date, time or type of table, you need to set these values as the filter criteria to get available values. For example, if a user has selected "Monday" as a date, the time frames you recommend should also be available for "Monday".
-2. Checking if the user input is valid. For example, if you are not open on "Monday" but the user input for the date is "Monday", you should tell the user that "Monday" is not valid.
-3. Inserting reservation information into your database. Besides the values the user inputs, reservation information should also include the user's ID so that you know who made this reservation. 
-
-The following function interfaces can be used to implement the above business logic. (`[]` means it has multiple values, `?` means it's nullable.)
-
-| Function Label       | Parameter            | Parameter Type                       | Return Type                      |
-|:---------------------|:---------------------|:-------------------------------------|:---------------------------------|
-| getTableInfo         | date_param           | Entity/java.time.LocalDate?          | Frame/TableInfo[]?               |
-|                      | time_param           | Entity/java.time.LocalTime?          |                                  |
-|                      | tableType_param      | Entity/TableType?                    |                                  |
-| makeReservation      | userId_param         | Entity/kolin.String                  | Frame/ReservationInfo?           |
-|                      | date_param           | Entity/java.time.LocalDate?          |                                  |
-|                      | tableType_param      | Entity/TableType?                    |                                  |
-|                      | time_param           | Entity/java.time.LocalTime?          |                                  |
-|                      | tableType_param      | Entity/TableType?                    |                                  |
-
-
-
-:tipping_hand_woman: Now you can add the above function interfaces in the **Service** field of the component. Before you move to the next step, don't forget to [view your changes](../reference/platform/versioncontrol.md#review-changes) and merge them into the master.
-
-## Provider
-In this section, you learn how to create tables in the PostgreSQL database using a [postgrest provider](../reference//providers/postgrest.md#overview) and  implement a service interface in a [provider](../guide/concepts.md#providers).
-
-### Import Component
+## Import Component
 :tipping_hand_woman: First, follow these steps to import a component to your provider.
 1. [Create a postgrest provider](../reference//providers/postgrest.md#create-postgrest-provider).
-2. [Import](../reference//providers/postgrest.md#declare-service-interface) the [reservation component](#component) into the provider. 
+2. [Import](../reference//providers/postgrest.md#declare-service-interface) the [reservation component](./reservation-service.md#create-types) into the provider. 
 
-### Create ables 
+## Create Tables 
 To get available dates, time frames and types of tables, first you need tables to store this information. Next, you need another table to store the user's reservation. Here are the three tables you can use: 
 
 1. **TableStatus** stores the quantity of available tables in a period of time for each day and information about the table: the type of table, the minimum and the maximum of guests which the table requires. 
@@ -139,8 +64,8 @@ To get available dates, time frames and types of tables, first you need tables t
 | tableType   | TableType             |
 | status      | kotlin.Int            |
 
-### Implement functions 
-Once you've created tables, you can implement the [function interfaces](#add-function-interfaces) imported from the reservation component. By doing so, your business can get access to your database and perform [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operation within it.
+## Implement functions 
+Once you've created tables, you can implement the [function interfaces](./reservation-service.md#add-function-interfaces) imported from the reservation component. By doing so, your business can get access to your database and perform [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) operation within it.
 
 :tipping_hand_woman: Now [select a service interface](../reference/providers/postgrest.md#provide-function-implementation) to implement. Next, copy the following codes to implement corresponding functions. Before you start to integrate the provider with a chatbot, be sure to use the [function console](../reference/providers/postgrest.md#function-console) to test functions first.
 

--- a/docs/articles/reservation-service.md
+++ b/docs/articles/reservation-service.md
@@ -1,5 +1,5 @@
 ---
-article: false
+article: true
 date: 2022-12-26
 
 image:

--- a/docs/articles/reservation-service.md
+++ b/docs/articles/reservation-service.md
@@ -1,0 +1,139 @@
+---
+article: false
+date: 2022-12-26
+
+image:
+- blog/banner/tutorial_reservation_ii.png
+description:
+- We list the reservation API that supports making a reservation
+author: Sunny May
+---
+
+# Reservation API
+
+[[toc]]
+
+## Overview
+The Reservation API provides different services for [making a table reservation](./requirements-on-reservation.md#make-a-reservation). Following its definition, you can create the [type systems](../guide/concepts.md#type-systems) and [services](../guide/concepts.md#services) in a component. The sample of the service is [reservation](https://build.opencui.io/org/622c8ff683536204fe062b55/agent/63734ef820b0d2661d800404/service_schema). When you have problems in adding APIs, you can always refer to that component.
+
+## API Specification
+### <Badge type="warning" text="GET" vertical="middle"/> getTableInfo
+**Summary**
+
+Input parameters are set as the filter criteria to get the whole information for available tables. 
+
+**Parameter**
+```yaml
+- name: date_param
+  schema:
+    type : java.time.LocalDate
+  required: false
+  description: The date the user chooses for the reservation.  
+- name: time_param
+  schema:
+    type : java.time.LocalTime
+  required: false
+  description: The time the user chooses for the reservation.
+- name: tableType_param
+  schema:
+    type : TableType entity
+  required: false
+  description: The type of table the user chooses for the reservation.
+  
+```
+
+**Responses**
+```yaml
+description: A TableInfo object array
+content: 
+  application/json:
+    schema:
+      type: array
+      items:
+        type: object
+      properties:
+        date:
+          type: java.time.LocalDate
+          description: The available date.
+        startTime:
+          type: java.time.LocalTime
+          description: The start time of the available time frame.
+        endTime:
+          type: java.time.LocalTime
+          description: The end time of the available time frame. .
+        tableType:
+          type: TableType entity
+          description: The available type of table. 
+        minGuest:
+          type: kotlin.Int
+          description: The minimum number of guests which the table requires.
+        maxGuest:
+          type: kotlin.Int
+          description: The maximum number of guests which the table requires.
+```
+
+### <Badge text="POST" vertical="middle"/> makeReservation
+**Summary**
+
+Inserting reservation information into the database. 
+
+**Parameter**
+```yaml
+- name: userId_param
+  schema:
+    type: kolin.String
+  required: true
+  description: The user's ID.
+- name: date_param
+  schema:
+    type : java.time.LocalDate
+  required: true
+  description: The date the user chooses for the reservation.
+- name: time_param
+  schema:
+    type : java.time.LocalTime
+  required: true
+  description: The time the user chooses for the reservation.
+- name: tableType_param
+  schema:
+    type : TableType entity
+  required: true
+  description: The type of table the user chsoses for the reservation.
+  
+```
+**Responses**
+```yaml
+description: A ReservationInfo object array
+content: 
+  application/json:
+    schema:
+      type: array
+      items:
+        type: object
+      properties:
+        date:
+          type: java.time.LocalDate
+        time:
+          type: java.time.LocalTime
+        tableType:
+          type: TableType entity
+```
+
+## How To Add
+To add APIs for [making a reservation](./requirements-on-reservation.md#make-a-reservation), follow these procedures:
+
+### Create a Component
+Create a component with service enabled and [add the EN language](../reference/platform/multilingual.md#add-multi-language).
+
+### Create Types
+1. Create an [entity](../guide/concepts.md#entities) called **TableType**.
+2. Create two [frames](../guide/concepts.md#frames) to represent **ReservationInfo** object and **TableInfo** object.
+3. Add slots that are the same as properties of the object in each frame.
+
+::: tip Do NOT add instances to the TableType entity. Why?
+To make this component more flexible and let more people reuse it, you can leave the instance empty and let people who use this component add their own instances in their chatbots.
+:::
+
+### Add Function Interfaces
+1. Follow the [API specification](#api-specification), add function interfaces in the **Service** field of the component. 
+2. Before you move to the next step, don't forget to [view your changes](../reference/platform/versioncontrol.md#review-changes) and merge them into the master.


### PR DESCRIPTION
参考 [OpenAPI](https://swagger.io/docs/specification/basic-structure/) 将 service part 从 "_How to build a reservation chatbot_" 中移到新添加的 "_reservation API_" 文档中

Problem：
目前好像还不支持隐藏 blog 页面的某篇 article，我们需要支持这个功能吗？John 说这个功能挺好添加