### PR TITLE
update-url

### DIFF
--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -24,7 +24,7 @@ Services can be described by its schema, using description languages such as [Op
 
 A data type (or simply type) defines what operations can be applied to its instances, and the behavior on these instances resulted from these operations. As a conversational user interface framework, the types you can define on OpenCUI, including skill, frame and entity, have their conversational behavior defined in three layers. In schema layer, they are directly mapped into hosting language data types (currently Java/Kotlin) so that it can be used to invoke the service functions directly; in interaction layer, how to collect user preferences are defined via dialog annotation; finally in language layer, these same types directly encode the semantics of utterances, and builder can use exemplar and template to control how to convert between natural text and structured representation back and forth. 
 
-These pre-defined data types we support like [Java](https://build.opencui.io/org/5f531ff3b18cde225665fcf3/agent/5fa26c1a22714e8c5b7b9ea3/entity), [Kotlin](https://build.opencui.io/org/5f531ff3b18cde225665fcf3/agent/5fa21ced93f59e8e4f65839a/entity) are usually automatically imported into projects. If not, you can import them manually, and then you can view them under Imported tab.
+These pre-defined data types we support like [Java](https://build.opencui.io/org/system/agent/java/struct/entity), [Kotlin](https://build.opencui.io/org/system/agent/kotlin/struct/entity) are usually automatically imported into projects. If not, you can import them manually, and then you can view them under Imported tab.
 
 ### Skills
 Generally, a skill represents what a user wants, at the same time, it is essentially a function that a user can access through conversations for businesses. 

--- a/docs/reference/annotations/init.md
+++ b/docs/reference/annotations/init.md
@@ -12,7 +12,7 @@ The order will be under the same number "1202555xxxx" as last time. Ready to pla
 :::
 ::::
 
-There are other use cases where initialization can be useful. For example, when booking a vacation, after a user has booked a flight ticket, the bot can associate that flight arrival date and city for the start date and location for the subsequent hotel booking. View the whole conversation in [Testcase - Vacation](https://build.opencui.io/org/622c8ff683536204fe062b55/agent/62b12e4eede53f1b65047b11/test_case).
+There are other use cases where initialization can be useful. For example, when booking a vacation, after a user has booked a flight ticket, the bot can associate that flight arrival date and city for the start date and location for the subsequent hotel booking. 
 
 :::: conversation
 ::: bot Bot
@@ -31,7 +31,6 @@ You can provide the slot with an initial value by defining the association of th
   - You can pick an earlier slot of the same type as proposed value. If you pick a later slot, the behavior is not defined, meaning the behavior might change without notice.
 - Function call:
   - Regarding the first situation in [Motivation](#motivation), you can set the phone number as `getUserPhoneNumber()`, which returns the user's previous phone number.
-  - Go to [SKill: FoodOrdering](https://build.opencui.io/org/622c8ff683536204fe062b55/agent/62b12e4cede53f1b65047b0f/intent/62b12eacede53f1b65047b13) to learn more details.
   
 Beyond the normal operator like +,-,*,/, you can combine expressions using:
 - [If expression](./kotlinexpression.md#if-expression)

--- a/docs/reference/annotations/systemcomponent.md
+++ b/docs/reference/annotations/systemcomponent.md
@@ -231,7 +231,7 @@ For more information about Boolean Gate annotation, see [Gated](fillstrategy.md#
 
 ## User Identifier
 
-User identifier is a system frame that provides basic information of the user in a channel-dependent way. Once you've added a slot of which type is [`user.UserIdentifier`](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/633f953f28e4f04b5f8443b7/frame/633f953f28e4f04b5f84453e), when the user chats with bot in a channel, the bot can access the user ID, the type and the label of the channel. For example, in the [WhatsApp](../channels/whatsapp.md) channel, the user ID is the same as the user's phone number, the type of the channel is *whatsApp* and the label of the channel is defined by the chatbot builder.
+User identifier is a system frame that provides basic information of the user in a channel-dependent way. Once you've added a slot of which type is [`user.UserIdentifier`](https://build.opencui.io/org/io.opencui/agent/core/struct/frame/633f953f28e4f04b5f84453e), when the user chats with bot in a channel, the bot can access the user ID, the type and the label of the channel. For example, in the [WhatsApp](../channels/whatsapp.md) channel, the user ID is the same as the user's phone number, the type of the channel is *whatsApp* and the label of the channel is defined by the chatbot builder.
 
 With the information from user identifier, it's convenient for business to manage users along with their requests. For example, when the bot has confirmed the reservation information with users, it could store the reservation under the user ID and send the user ID back to the user. When the user comes for dinner, that ID can be used to get the reserved table.
 

--- a/docs/reference/annotations/valuecheck.md
+++ b/docs/reference/annotations/valuecheck.md
@@ -31,11 +31,6 @@ Value Check is an optional slot annotation. When [Slot Filling](../../guide/slot
 ![value check](/images/annotation/valuecheck/value-check.png)
 ::: 
 
-::: tip Try it with templates  
-1. Go to [ValueCheck](https://build.opencui.io/org/622c8ff683536204fe062b55/agent/6297f6d14cfdb2515448d814/test_case), see examples in Test Cases.
-2. Click **Try it now** > **Connect**, you can try it yourself.
-:::
-
 ### Conditions
 Condition holds the boolean code expression that checks whether the value user input is servable by business. If all conditions are true, Value Check passes. If one of the conditions is false, Value Check fails.
 

--- a/docs/reference/channels/googlebusiness.md
+++ b/docs/reference/channels/googlebusiness.md
@@ -47,7 +47,7 @@ Your browser downloads the service account key. Store it in a secure location. Y
 
 ## Configure Google Business Message From OpenCUI
 
-1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/63479c58bb57d84573e65ee8/service_schema): 
+1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/io.opencui/agent/channel/struct/service_schema): 
    1. Click **Import** button on the second topbar.
    2. Select the chatbot you want to configure Google Business Message channel and **Save**.
 

--- a/docs/reference/channels/messenger.md
+++ b/docs/reference/channels/messenger.md
@@ -39,7 +39,7 @@ On the Messenger side, please ensure you have all of the following:
 
 ## Configure Messenger From OpenCUI
 
-1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/63479c58bb57d84573e65ee8/service_schema): 
+1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/io.opencui/agent/channel/struct/service_schema): 
    1. Click **Import** button on the second topbar.
    2. Select the chatbot you want to configure Messenger channel and **Save**.
 

--- a/docs/reference/channels/whatsapp.md
+++ b/docs/reference/channels/whatsapp.md
@@ -56,7 +56,7 @@ In the Business Manager, go to your [Business Settings](https://business.faceboo
 
 ## Configure WhatsApp From OpenCUI
 
-1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/63479c58bb57d84573e65ee8/service_schema): 
+1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/io.opencui/agent/channel/struct/service_schema): 
    1. Click **Import** button on the second topbar.
    2. Select the chatbot you want to configure WhatsApp channel and **Save**.
 

--- a/docs/reference/channels/wpa.md
+++ b/docs/reference/channels/wpa.md
@@ -34,7 +34,7 @@ If you used *Developer Password(AppSecret)* before but didn't store it, you can 
 
 ## Configure WeChat From OpenCUI
 
-1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/63479c58bb57d84573e65ee8/service_schema): 
+1. On OpenCUI platform, go to service component [io.opencui.channel](https://build.opencui.io/org/io.opencui/agent/channel/struct/service_schema): 
    1. Click **Import** button on the second topbar.
    2. Select the chatbot you want to configure WeChat channel and **Save**.
 

--- a/docs/reference/providers/googlesheets.md
+++ b/docs/reference/providers/googlesheets.md
@@ -6,7 +6,7 @@
 
 [Google Sheets](https://www.google.com/sheets/about/#overview) is a web-based application that enables users to create, update and modify spreadsheets and share the data online in real time.
 
-Google Sheets provider allow you to use Google Sheets as backend, which the actual data can be managed by your operation team in online spreadsheet collaboratively. Through Google Sheets provider, you can query data from your spreadsheet using the [Query Language](https://developers.google.com/chart/interactive/docs/querylanguage) and update data with the help of low level functions in [io.opencui.provider.GoogleSheetsConnection](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/6340dea9815fc9881cbbbfe7/frame/6340dea9815fc9881cbbbfea).
+Google Sheets provider allow you to use Google Sheets as backend, which the actual data can be managed by your operation team in online spreadsheet collaboratively. Through Google Sheets provider, you can query data from your spreadsheet using the [Query Language](https://developers.google.com/chart/interactive/docs/querylanguage) and update data with the help of low level functions in `io.opencui.provider.GoogleSheetsConnection`.
 
 ::: thumbnail
 ![data management](/images/provider/googlesheets/data-management.png)
@@ -81,7 +81,7 @@ To get your business data from a spreadsheet, you can write a query in **provide
 
 ### Kotlin Functions
 
-To update and append your business, OpenCUI provides external functions: _update_ and _append_. You can call these functions using `connection.update` and `connection.append` in Kotlin functions. Check out the definitions of these functions in [io.opencui.provider.GoogleSheetsConnection](https://build.opencui.io/org/633db11928e4f04b5f8443b4/agent/6340dea9815fc9881cbbbfe7/frame/6340dea9815fc9881cbbbfea). To learn the source of the function, see [spreadsheets.values.update](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/update) and [spreadsheets.values.append](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append).
+To update and append your business, OpenCUI provides external functions: _update_ and _append_. You can call these functions using `connection.update` and `connection.append` in Kotlin functions. Check out the definitions of these functions in `io.opencui.provider.GoogleSheetsConnection`. To learn the source of the function, see [spreadsheets.values.update](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/update) and [spreadsheets.values.append](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/append).
 
 - The input parameters are the same in these two functions. 
 


### PR DESCRIPTION
Platform 相关链接修改：
1. Blog 中的没有改，预期 reservation 相关的之后会改；
2. 文档中没有找到对应关系的 agent，暂时直接 remove 了。因为过去是 id，现在是 label，文档中也没有注明全名就暂时给去掉了。
3. 未来可以提供 url，不过应该是告诉大家怎么搜索找到对应 agent。因为 agent url 总是在变化，每一次 label 的修改，都会导致该 url 的实效。