### PR TITLE
fix case in quickstart

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -2,7 +2,7 @@
 export const en = {
   '/guide/': [
     {
-      text: 'Step by Step',
+      text: 'Step by step',
       children: [
         '/guide/are-you-ready.md',
         '/guide/signingup.md',

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -5,25 +5,25 @@ The OpenCUI platform can be useful at various stages of chatbot development, suc
 
 While we build OpenCUI based on many best practices in building user interface applications, to deal with the unique challenges presented in building CUI, such as user can say anything at any time, we need to introduce some unique solutions. The conceptual model that is needed for one to take full advantage of OpenCUI, thus need a bit of practice to get used to. To assist you in this, we have developed a series of tutorials that aim to guide you step-by-step in understanding the conceptual model and becoming proficient in using OpenCUI to build exceptional conversational experiences. 
 
-#### [Before You Start](are-you-ready.md)
+#### [Before you start](are-you-ready.md)
 If you are serious about use OpenCUI in production, you might want to make sure you are prepared.
 
-#### [Sign Up](signingup.md)
+#### [Sign up](signingup.md)
 Before we fully open up, we required you signup first so that we can get some idea on how we can help you. All you need is a GitHub account, ideally with your email verified. 
 
-#### [Clone and Play](start-with-clone.md)
+#### [Clone a chatbot](start-with-clone.md)
 Cloning an existing project is the fastest way to start play with it. This guide show you how to clone a project, so that you do not have to start from scratch.
 
-#### [Test](debug.md)
+#### [Test a chatbot](debug.md)
 Before you deploy your bot to production environment, you can test its behavior using the builtin **Debug** tool.
 
-#### [Quickstart with PingPong](pingpong.md)
+#### [Build a simple chatbot](pingpong.md)
 This guide walks you through how to create a basic chatbot on the OpenCUI platform. The sample provides a quick way to explore the functionality of a chatbot, and it can serve as a starting point for your chatbot development. 
 
-#### [Interactions with Channels](quickstart-channel.md)
+#### [Deploy a chatbot](quickstart-channel.md)
 This guide walks you through how to use the builtin version control system to review and merge your change to master. It explains to you how chatbot work with messaging platform like Messenger, and shows you how to configure both side using Messenger as example. After going through this, you should be able to interact with your chatbot in Messenger. 
 
-#### [Table Reservation](quickstart-reservation.md)
+#### [Import a module](quickstart-reservation.md)
 Reusable module can greatly reduce the cost of building chatbot. In this guide, we show you how to import a table reservation module, configure the provider so that you can start to provide table reservation through conversational user interface in no time.
 
 

--- a/docs/guide/are-you-ready.md
+++ b/docs/guide/are-you-ready.md
@@ -1,21 +1,21 @@
-# Before You Start
+# Before you start
 
 OpenCUI is a low code platform that allows you to build schema grounded conversational user interface (CUI) for your service APIs, in a declarative and component based fashion. It is designed to help regular business development team build great CUI for your service, without hiring special talents like NLU Ph.D on your team. Instead of focusing on the conversations, OpenCUI allows you to focus on the data structures, APIs and interaction logic and takes care of context dependent dialog understanding based on just a few examples. To take full advantage of OpenCUI, these are the couple things you might want to get ready. 
 
-## APIs for the Services
+## APIs for the services
 
 First you need to decide what service you want to provide through chatbot. For example, if you are restaurant, you might decide that you want to expose table reservation, food orders, hours, direction and maybe jobs. Each of these functionalities or what we call them service should be decided before you try to build the related chatbot. 
 
 OpenCUI can only help you to build CUI, you will have to build your service and make them available via some APIs. OpenCUI can integrate easily with native Java/Koltin service providers and restful providers. And you can make use of full stack component on the OpenCUI repository.
 
-## Interaction Logic Owner
+## Interaction logic owner
 
 As with any user facing application, someone needs to own the interaction logic. As conversational application, the mode of the interaction is via language text. However, conversational user interface in OpenCUI are schema grounded, which basically means that interaction can be expressed/reasoned in a language independent fashion, in form of dialog act. 
 
 The success of any chatbot project requires you have a CUI product manager. This person should have direct access to product owner and can make tradeoff between features. Ideally this person understands your business really well (a must) and have background in the CUI (a good to have). It is understood that there are not many people with CUI product experience, which is ok. OpenCUI has a well-defined declarative way of defining interaction logic, the learning curve is very friendly.
 
-## Have Operation Team Ready
+## Have operation team ready
 Creating the CUI for your business is just the first step, you need to have operation team, so you can bring the chatbot online. This is important for two reasons. First, language is a very complex thing, it is hard for you to get it dialog understanding right in one shot, so it is essential to monitor the actual conversations and provide expression to continuously to improve dialog understanding for your domain. Second, with CUI, a user can ask for services that you are not prepared, this is a good opportunity for you to figure out what other features should be developed next. The good thing about CUI is, you do not have to educate your user, if they need a feature, they will find you.
 
-## Budget Engineering Resource
+## Budget engineering resource
 When you need to work with channels/support/services that is not currently supported by OpenCUI runtime, you will need to budget some engineering resource. OpenCUI's extensible due to its plug-and-play design, but it will require you to have engineering resource.

--- a/docs/guide/debug.md
+++ b/docs/guide/debug.md
@@ -26,11 +26,11 @@ You can make modifications, such as changing the response and expression. For th
 ## Reset session
 The replies that bot generated for the user input depends on the conversation history. Sometime, you need to have a clean start to try something, you can restart your testing session by clicking the "**Reset Contexts**" icon.
 
-## View Log
+## View log
 For coders, you can inspect the detailed log by clicking the "**View Log**" icon.
 
 ## Save test case
 You can save test cases by clicking the "**Save Test Case**" icon, which allow you rerun them in a later stage. For more information about Debug, refer to the [Testing](../reference/platform/testing.md) section.
 
-### Next steps
+## Next steps
 Now you know how you can test a chatbot, let's see how you can [build a simple chatbot](pingpong.md).

--- a/docs/guide/pingpong.md
+++ b/docs/guide/pingpong.md
@@ -65,7 +65,7 @@ If the chatbot is created successfully, it should be displayed as shown below:
 Chatbots allow user access functions through CUI, and CUI behavior for an exposed function is defined in its corresponding skill. The input parameters of a function are represented by slots in the skill, and the type of these parameters, along with CUI behavior for these types are defined as frames and entities, with frames for composite and polymorphic types, and entities for primitive types. Service is a set of functions, so chatbot is simply a set of skills. Building a chatbot is simply building skills one at a time.
 
 
-CUI can be divided into interaction and language layer. The language layer are responsible for converting between natural language text and semantics (structured representation of meaning), interaction logic (also known as dialog management), decide how bot should react in semantics. For more information about each of the layers, see [3 Layers of Chatbot](3layers.md).
+CUI can be divided into interaction and language layer. The language layer are responsible for converting between natural language text and semantics (structured representation of meaning), interaction logic (also known as dialog management), decide how bot should react in semantics. For more information about each of the layers, see [3 layers of chatbot](3layers.md).
 
 In this tutorial, let's see how we can define a simple skill, the one without any slots in the following 4 steps. 
 

--- a/docs/guide/quickstart-channel.md
+++ b/docs/guide/quickstart-channel.md
@@ -8,15 +8,15 @@ Once you have developed and tested your chatbot, you can deploy it and start to 
 
 How does it work? Let's use Messenger as example. User send a message using the client software to Messenger platform, and Messenger platform forward that message to the end point that your channel implementation listens, upon get the user input, chatbot produce output, and ask channel implementation send the reply to the end point that Messenger platform listens, which will forward the reply to end user. Clearly to make this work, one have to configure on both Messenger platform side, and OpenCUI side, so that they both know where to send message to. 
 
-This guide builds on top of [Quickstart with PingPong](pingpong.md), is designed to show you how to integrate your chatbot with the Messenger channel. Channel are only supported in OpenCUI production environment, and to deploy your change to production environment, you need to create the PR, and merge it into master.
+This guide builds on top of [Build a simple chatbot](pingpong.md), is designed to show you how to integrate your chatbot with the Messenger channel. Channel are only supported in OpenCUI production environment, and to deploy your change to production environment, you need to create the PR, and merge it into master.
 
 ## Before you start
-Make sure to complete the steps outlined in the [Quickstart with PingPong](./pingpong.md) guide. The steps in this guide build upon the chatbot created in the previous guide.
+Make sure to complete the steps outlined in the [Build a simple chatbot](./pingpong.md) guide. The steps in this guide build upon the chatbot created in the previous guide.
 
 ## Merge changes
 OpenCUI comes with a Git like version control system, that is specifically designed for the structured chatbot definition so that we can manage the definition across modules and languages accurately. If you used Git in your development, this process should be very similar.
 
-After you tested your change, t's important to ask project owner to review your changes and ensure they meet the chatbot's features and quality standards, by opening a pull request and comparing the changes across your branch. Once your change is approved, you can merge them into the master. For more information on working with branch and reviewing changes, please refer to the [Version Control](../reference/platform/versioncontrol.md) section.
+After you tested your change, t's important to ask project owner to review your changes and ensure they meet the chatbot's features and quality standards, by opening a pull request and comparing the changes across your branch. Once your change is approved, you can merge them into the master. For more information on working with branch and reviewing changes, please refer to the [Version control](../reference/platform/versioncontrol.md) section.
 
 To create a pull request:
 1. In the second navigation bar, select the **Version** tab.
@@ -34,7 +34,7 @@ To review changes:
    ::: thumbnail
    ![review changes](/images/guide/pingpong/review_changes.png)
    :::
-3. Once you're satisfied with the changes, you can **Approve** them and **Merge** them into master. For more information about changes review, see [Version Contorl](../reference/platform/versioncontrol.md).
+3. Once you're satisfied with the changes, you can **Approve** them and **Merge** them into master. For more information about changes review, see [Version contorl](../reference/platform/versioncontrol.md).
 
 ## Setup channels
 
@@ -65,7 +65,7 @@ Here are the steps on how to set up and enable a channel, specifically using Mes
    :::
 
 4. Configure the Messenger channel:
-   1. Follow the steps in [Set Up Messenger](../reference/channels/messenger.md#set-up-messenger) to set up your Meta app, **generate access token** and copy this value to OpenCUI.
+   1. Follow the steps in [Set up Messenger](../reference/channels/messenger.md#set-up-messenger) to set up your Meta app, **generate access token** and copy this value to OpenCUI.
    2. Configure the integration: 
       - **Label**: Set a label for this channel, should be unique. 
       - **Verify Token**: You can enter any private token you desire. Copy this value. This will be used to configure Messenger Webhook.
@@ -101,4 +101,4 @@ The Deploy action allows you to publish the latest master of your chatbot to the
    ![deploy checked icon](/images/guide/pingpong/deploy_checked_icon.png)
    :::
 
-3. You can now complete the setup of your Meta app and test it out. To configure the Messenger Webhook, use the **Callback URL** and **Verify Token** values that you copied earlier and follow the instructions in the [Finish Setup Messenger](../reference/channels/messenger.md#finish-setup-messenger) and [Test Your Chatbot](../reference/channels/messenger.md#test-your-chatbot) section.
+3. You can now complete the setup of your Meta app and test it out. To configure the Messenger Webhook, use the **Callback URL** and **Verify Token** values that you copied earlier and follow the instructions in the [Finish setup Messenger](../reference/channels/messenger.md#finish-setup-messenger) and [Test your chatbot](../reference/channels/messenger.md#test-your-chatbot) section.

--- a/docs/guide/signingup.md
+++ b/docs/guide/signingup.md
@@ -1,4 +1,4 @@
-# Sign Up
+# Sign up
 > Create and log in to your OpenCUI account.
 
 You can start using OpenCUI to build your Chatbots by signing up for a Starter workspace plan, which is good for developers and freelancers who want to build and share. You can also upgrade your workspace plans for both individuals and teams, add and remove team members and collaborators. 
@@ -7,9 +7,9 @@ Follow the following steps to get a OpenCUI account. Let's begin:
 
 [[toc]]
 
-### Sign Up for an Account
+### Sign up for an account
 
-To create your starter OpenCUI account, please visit the [Sign Up page](https://docs.google.com/forms/d/e/1FAIpQLSeYGRXfYnB_uDKTS4hUfcD3w1f9LDI9swcC5Qhy71PTS_JANA/viewform):
+To create your starter OpenCUI account, please visit the [Sign up page](https://docs.google.com/forms/d/e/1FAIpQLSeYGRXfYnB_uDKTS4hUfcD3w1f9LDI9swcC5Qhy71PTS_JANA/viewform):
 > If you already had access to OpenCUI, you can skip this step and [log into your account](#log-into-your-account) directly. 
 
 ::: thumbnail
@@ -36,9 +36,9 @@ After submitting, if you get the response *“Thanks for taking the time to fill
 
 You will wait for an Email notification, which will inform you that you now have access to OpenCUI with your GitHub account, and you can log into your OpenCUI account now 🎉.
 
-### Log Into Your Account
+### Log in to your account
 
-To log into your OpenCUI with your GitHub account, you should open the [Login page](https://build.opencui.io/login) and click the **Sign in with GitHub** button: 
+To log in to your OpenCUI with your GitHub account, you should open the [Login page](https://build.opencui.io/login) and click the **Sign in with GitHub** button: 
 
 ::: thumbnail
 ![sign in](/images/guide/signup/sign-in.png)
@@ -50,9 +50,9 @@ If you don't have account yet, you can click the hyperlink **Click to sign up** 
 ![click to sign up](/images/guide/signup/click-to-sign-up.png)
 :::
 
-### Are You Ready
+### Are you ready
 
 Before beginning to build your first chatbot, you should be familiar with the following materials:
 
-1. [Build Conversational App](/guide/README.md)
-2. [Before You Start](/guide/are-you-ready.md)
+1. [Build conversational app](/guide/README.md)
+2. [Before you start](/guide/are-you-ready.md)

--- a/docs/guide/start-with-clone.md
+++ b/docs/guide/start-with-clone.md
@@ -14,7 +14,7 @@ When you clone a project, you create an exact copy in your organization that you
 
 [Sign up](./signingup.md#sign-up) for an account and log in to [OpenCUI](https://build.opencui.io/login).
 
-## Clone chatbot pingpont
+## Clone chatbot pingpong
 
 In OpenCUI, you can discover a growing number of public projects by clicking **Explore** tab at the top of the page, which was built by the OpenCUI community, you can inspect the project to see if it fits your needs. Once you are inside project you want to clone, you can follow steps below to accomplishded clone.
 


### PR DESCRIPTION
1. Fix quickstart 中大小写的问题
   - 统一将标题改为仅首字母大写
   - 在句子中引用文章时，文章标题仅首字母大写

2. 更新 quickstart 中引用的 quickstart 的标题 (e.g. _Quickstart with pingpong_ 改为 _Build a simple chatbot_)
3. Fix 不正确的标题层级和标题拼写