### PR TITLE
update index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hero:
       type: primary
     - theme: alt
       text: Learn More
-      link: /guide/
+      link: /reference/guide/index
       type: secondary
 features:
   - title: 💬 CUI for your APIs
@@ -39,18 +39,11 @@ features:
 cta :
   - details: Import what you need, customize and deploy.
     title: Get Started
-    link: /guide/
+    link: /reference/guide/index
 
 ---
 
 <script setup>
   import Cta from './components/cta/callToAction.vue';
 </script>
-<Cta :frontmatter="[
-  {
-    details: 'Import what you need, customize and deploy.',
-    title: 'Get Started',
-    link: '/guide/'
-  }
-]"
-/>
+<Cta />


### PR DESCRIPTION
fix links

由于 yaml 中传入了 cta 的参数，之前 cta frontmatter 定义的参数用不到，所以这里移除了 frontmatter